### PR TITLE
Updated to Dataverse.Client version 0.5.10

### DIFF
--- a/FakeXrmEasy.9.NetCore/FakeXrmEasy.9.NetCore.csproj
+++ b/FakeXrmEasy.9.NetCore/FakeXrmEasy.9.NetCore.csproj
@@ -2,14 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-	<DefineConstants>FAKE_XRM_EASY_DOTNETCORE,FAKE_XRM_EASY_9</DefineConstants>
+    <DefineConstants>FAKE_XRM_EASY_DOTNETCORE,FAKE_XRM_EASY_9</DefineConstants>
+    <Version>1.57.10</Version>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
-	<Import Project="..\FakeXrmEasy.Shared\FakeXrmEasy.Shared.projitems" Label="Shared" />
-	<ItemGroup>
-	  <PackageReference Include="FakeItEasy" Version="7.0.1" />
-	  <PackageReference Include="Microsoft.Dynamics.Sdk.Messages" Version="0.4.6" />
-	  <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.6" />
-	  <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="0.4.6" />
-	  <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
-	</ItemGroup>
+  <Import Project="..\FakeXrmEasy.Shared\FakeXrmEasy.Shared.projitems" Label="Shared" />
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Dynamics.Sdk.Messages" Version="0.5.10" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.10" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="0.5.10" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
+  </ItemGroup>
 </Project>

--- a/FakeXrmEasy.Tests.9.NetCore/FakeXrmEasy.Tests.9.NetCore.csproj
+++ b/FakeXrmEasy.Tests.9.NetCore/FakeXrmEasy.Tests.9.NetCore.csproj
@@ -5,21 +5,21 @@
     <RootNamespace>FakeXrmEasy.Tests.NetCore</RootNamespace>
 
     <IsPackable>false</IsPackable>
-	<DefineConstants>FAKE_XRM_EASY_DOTNETCORE,FAKE_XRM_EASY_9</DefineConstants>
-	  <Version>1.57.1</Version>
-	  <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-	  <SignAssembly>true</SignAssembly>
-	  <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
-	  <PackageId>FakeXrmEasy.Tests.9.NetCore</PackageId>
-	  <Product>FakeXrmEasy.Tests.9.NetCore</Product>
+    <DefineConstants>FAKE_XRM_EASY_DOTNETCORE,FAKE_XRM_EASY_9</DefineConstants>
+    <Version>1.57.1</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
+    <PackageId>FakeXrmEasy.Tests.9.NetCore</PackageId>
+    <Product>FakeXrmEasy.Tests.9.NetCore</Product>
   </PropertyGroup>
-	<Import Project="..\FakeXrmEasy.Tests.Shared\FakeXrmEasy.Tests.Shared.projitems" Label="Shared" />
+  <Import Project="..\FakeXrmEasy.Tests.Shared\FakeXrmEasy.Tests.Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Dynamics.Sdk.Messages" Version="0.4.6" />
+    <PackageReference Include="Microsoft.Dynamics.Sdk.Messages" Version="0.5.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.6" />
-    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="0.4.6" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.10" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="0.5.10" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />


### PR DESCRIPTION
I just updated to Dataverse.Client version 0.5.10 and explicitly bumped FakeXrmEasy.9.NetCore to Version 1.57.10. Build number of this version is the build number of the Dataverse.Client.

Maybe the version numbering is not the best choice. Please correct it for the case you incorporate this pull request. Otherwise I encountered that three of the ConditionOperatorTests are failing: *_Week_Execution.